### PR TITLE
Fix rogue unescaped span

### DIFF
--- a/plain_html.py
+++ b/plain_html.py
@@ -12,7 +12,7 @@ def elements_to_delete():
                            'output', 'progress', 'select', 'textarea']
     html5_image_elements = ['area', 'img', 'map', 'picture', 'source']
     html5_media_elements = ['audio', 'track', 'video']
-    html5_embedded_elements = ['embed', 'math', 'object', 'param', 'svg']
+    html5_embedded_elements = ['embed', 'iframe', 'math', 'object', 'param', 'svg']
     html5_interactive_elements = ['details', 'dialog', 'summary']
     html5_scripting_elements = ['canvas', 'noscript', 'script', 'template']
     html5_data_elements = ['data', 'link']

--- a/tests/checks.py
+++ b/tests/checks.py
@@ -19,8 +19,7 @@ def check_extract_article(test_filename, expected_filename, content_digests=Fals
     """Test end-to-end article extraction. Ensure that HTML from file matches JSON from file after parsing is applied."""
     test_data_dir = "data"
     # Read HTML test file
-    test_filepath = os.path.join(os.path.dirname(
-        __file__), test_data_dir, test_filename)
+    test_filepath = os.path.join(os.path.dirname(__file__), test_data_dir, test_filename)
     with open(test_filepath) as h:
         html = h.read()
 
@@ -28,8 +27,7 @@ def check_extract_article(test_filename, expected_filename, content_digests=Fals
     article_json = readability.parse(html, content_digests, node_indexes)
 
     # Get expected simplified article HTML
-    expected_filepath = os.path.join(os.path.dirname(__file__),
-                                     test_data_dir, expected_filename)
+    expected_filepath = os.path.join(os.path.dirname(__file__), test_data_dir, expected_filename)
     with open(expected_filepath) as h:
         expected_article_json = json.loads(h.read())
 
@@ -40,8 +38,7 @@ def check_extract_article(test_filename, expected_filename, content_digests=Fals
 def check_extract_paragraphs_as_plain_text(test_filename, expected_filename):
     test_data_dir = "data"
     # Read readable article test file
-    test_filepath = os.path.join(os.path.dirname(__file__),
-                                 test_data_dir, test_filename)
+    test_filepath = os.path.join(os.path.dirname(__file__), test_data_dir, test_filename)
     with open(test_filepath) as h:
         article = json.loads(h.read())
 

--- a/tests/checks.py
+++ b/tests/checks.py
@@ -1,0 +1,90 @@
+import json
+import os
+from ReadabiliPy import readability, text_manipulation
+
+def check_exact_html_output(test_fragment, expected_output=None):
+    """Check that expected output is present when parsing HTML fragment."""
+    if expected_output is None:
+        expected_output = test_fragment
+    article_json = readability.parse(test_fragment)
+    content = str(article_json["plain_content"])
+    # Check that expected output is present after simplifying the HTML
+    normalised_output = text_manipulation.simplify_html(expected_output)
+    normalised_content = text_manipulation.simplify_html(content)
+    print(normalised_content)
+    assert normalised_output == normalised_content
+
+
+def check_extract_article(test_filename, expected_filename, content_digests=False, node_indexes=False):
+    """Test end-to-end article extraction. Ensure that HTML from file matches JSON from file after parsing is applied."""
+    test_data_dir = "data"
+    # Read HTML test file
+    test_filepath = os.path.join(os.path.dirname(
+        __file__), test_data_dir, test_filename)
+    with open(test_filepath) as h:
+        html = h.read()
+
+    # Extract simplified article HTML
+    article_json = readability.parse(html, content_digests, node_indexes)
+
+    # Get expected simplified article HTML
+    expected_filepath = os.path.join(os.path.dirname(__file__),
+                                     test_data_dir, expected_filename)
+    with open(expected_filepath) as h:
+        expected_article_json = json.loads(h.read())
+
+    # Test full JSON matches (checks for unexpected fields in either actual or expected JSON)
+    assert article_json == expected_article_json
+
+
+def check_extract_paragraphs_as_plain_text(test_filename, expected_filename):
+    test_data_dir = "data"
+    # Read readable article test file
+    test_filepath = os.path.join(os.path.dirname(__file__),
+                                 test_data_dir, test_filename)
+    with open(test_filepath) as h:
+        article = json.loads(h.read())
+
+    # Extract plain text paragraphs
+    paragraphs = readability.extract_text_blocks_as_plain_text(
+        article["plain_content"])
+
+    # Get expected plain text paragraphs
+    expected_filepath = os.path.join(os.path.dirname(__file__),
+                                     test_data_dir, expected_filename)
+    with open(expected_filepath) as h:
+        expected_paragraphs = json.loads(h.read())
+
+    # Test
+    assert paragraphs == expected_paragraphs
+
+
+def check_html_output_contains_text(test_fragment, expected_output=None):
+    """Check that expected output is present when parsing HTML fragment."""
+    if expected_output is None:
+        expected_output = test_fragment
+    article_json = readability.parse(test_fragment)
+    content = str(article_json["plain_content"])
+    # Check that expected output is present after simplifying the HTML
+    normalised_output = text_manipulation.simplify_html(expected_output)
+    normalised_content = text_manipulation.simplify_html(content)
+    assert normalised_output in normalised_content
+
+
+def check_html_has_no_output(test_fragment):
+    """Check that no output is present when parsing HTML fragment."""
+    article_json = readability.parse(test_fragment)
+    # Check that there is no output
+    assert article_json["plain_content"] is None or article_json["plain_content"] == "<div></div>"
+
+
+def check_html_output_does_not_contain_tag(test_fragment, vetoed_tag):
+    """Check that vetoed tag is not present when parsing HTML fragment."""
+    article_json = readability.parse(test_fragment)
+    # Check that neither <tag> nor </tag> appear in the output
+    content = str(article_json["plain_content"])
+    if content is not None:
+        for element in ["<{}>".format(vetoed_tag), "</{}>".format(vetoed_tag)]:
+            assert element not in content
+
+

--- a/tests/test_html_elements.py
+++ b/tests/test_html_elements.py
@@ -1,36 +1,6 @@
 """Tests for HTML elements."""
 from pytest import mark
-from ReadabiliPy import readability, text_manipulation
-
-
-def check_html_output_contains_text(test_fragment, expected_output=None):
-    """Check that expected output is present when parsing HTML fragment."""
-    if expected_output is None:
-        expected_output = test_fragment
-    article_json = readability.parse(test_fragment)
-    content = str(article_json["plain_content"])
-    # Check that expected output is present after simplifying the HTML
-    normalised_output = text_manipulation.simplify_html(expected_output)
-    normalised_content = text_manipulation.simplify_html(content)
-    assert normalised_output in normalised_content
-
-
-def check_html_has_no_output(test_fragment):
-    """Check that no output is present when parsing HTML fragment."""
-    article_json = readability.parse(test_fragment)
-    # Check that there is no output
-    assert article_json["plain_content"] is None or article_json["plain_content"] == "<div></div>"
-
-
-def check_html_output_does_not_contain_tag(test_fragment, vetoed_tag):
-    """Check that vetoed tag is not present when parsing HTML fragment."""
-    article_json = readability.parse(test_fragment)
-    # Check that neither <tag> nor </tag> appear in the output
-    content = str(article_json["plain_content"])
-    if content is not None:
-        for element in ["<{}>".format(vetoed_tag), "</{}>".format(vetoed_tag)]:
-            assert element not in content
-
+from .checks import check_html_output_contains_text, check_html_has_no_output, check_html_output_does_not_contain_tag
 
 # Whitelisted HTML elements
 def test_html_whitelist_article():

--- a/tests/test_plain_html_functions.py
+++ b/tests/test_plain_html_functions.py
@@ -1,4 +1,4 @@
-"""Tests for HTML elements."""
+"""Tests for plain_html functions."""
 from bs4 import BeautifulSoup
 from ReadabiliPy import plain_html
 

--- a/tests/test_readability.py
+++ b/tests/test_readability.py
@@ -1,45 +1,7 @@
 """Test readability.py on sample articles"""
-import json
-import os
-from ReadabiliPy import readability, text_manipulation
+from .checks import check_exact_html_output, check_extract_article, check_extract_paragraphs_as_plain_text
 
-# ===== TEST END TO END ARTICLE EXTRACTION =====
-
-
-def check_extract_article(test_filename, expected_filename, content_digests=False, node_indexes=False):
-    test_data_dir = "data"
-    # Read HTML test file
-    test_filepath = os.path.join(os.path.dirname(
-        __file__), test_data_dir, test_filename)
-    with open(test_filepath) as h:
-        html = h.read()
-
-    # Extract simplified article HTML
-    article_json = readability.parse(html, content_digests, node_indexes)
-    print(article_json)
-
-    # Get expected simplified article HTML
-    expected_filepath = os.path.join(os.path.dirname(__file__),
-                                     test_data_dir, expected_filename)
-    with open(expected_filepath) as h:
-        expected_article_json = json.loads(h.read())
-
-    # Test full JSON matches (checks for unexpected fields in either actual or expected JSON)
-    assert article_json == expected_article_json
-
-
-def check_exact_html_output(test_fragment, expected_output=None):
-    """Check that expected output is present when parsing HTML fragment."""
-    if expected_output is None:
-        expected_output = test_fragment
-    article_json = readability.parse(test_fragment)
-    content = str(article_json["plain_content"])
-    # Check that expected output is present after simplifying the HTML
-    normalised_output = text_manipulation.simplify_html(expected_output)
-    normalised_content = text_manipulation.simplify_html(content)
-    assert normalised_output == normalised_content
-
-
+# Test end-to-end article extraction
 def test_extract_article_full_page():
     check_extract_article(
         "addictinginfo.com-1_full_page.html",
@@ -123,30 +85,7 @@ def test_extract_article_full_page_content_digest_node_indexes():
     )
 
 
-# ==== TEST PLAIN TEXT EXTRACTION =====
-def check_extract_paragraphs_as_plain_text(test_filename, expected_filename):
-    test_data_dir = "data"
-    # Read readable article test file
-    test_filepath = os.path.join(os.path.dirname(__file__),
-                                 test_data_dir, test_filename)
-    with open(test_filepath) as h:
-        article = json.loads(h.read())
-
-    # Extract plain text paragraphs
-    paragraphs = readability.extract_text_blocks_as_plain_text(
-        article["plain_content"])
-
-    # Get expected plain text paragraphs
-    expected_filepath = os.path.join(os.path.dirname(__file__),
-                                     test_data_dir, expected_filename)
-    with open(expected_filepath) as h:
-        expected_paragraphs = json.loads(h.read())
-
-    # Test
-    print(paragraphs)
-    assert paragraphs == expected_paragraphs
-
-
+# Test plain text extraction
 def test_extract_paragraphs_as_plain_text():
     check_extract_paragraphs_as_plain_text(
         "addictinginfo.com-1_simple_article_from_full_article.json",

--- a/tests/test_weird_html.py
+++ b/tests/test_weird_html.py
@@ -1,0 +1,35 @@
+"""Tests for weird HTML input."""
+from .checks import check_exact_html_output
+
+def test_non_printing_control_characters():
+    """Non-printing characters should be removed."""
+    check_exact_html_output("""
+        <div>
+            <p>First paragraph.</p>
+            <p><span>﻿</span></p>
+            <p>Last paragraph.</p>
+        </div>
+    """, """
+        <div>
+            <p>First paragraph.</p>
+            <p>Last paragraph.</p>
+        </div>
+    """)
+
+
+def test_iframe_containing_tags():
+    """At present we blacklist iframes completely"""
+    check_exact_html_output("""
+        <div>
+            <iframe><span>text</span></iframe>
+        </div>
+    """, "<div></div>")
+
+
+def test_iframe_with_source():
+    """At present we blacklist iframes, but may want to extract the links in future."""
+    check_exact_html_output("""
+        <div>
+            <iframe src="https://www.youtube.com/embed/BgB5E91lD6s" width="640" height="355" frameborder="0" allowfullscreen="allowfullscreen"></iframe>
+        </div>
+    """, "<div></div>")

--- a/text_manipulation.py
+++ b/text_manipulation.py
@@ -21,6 +21,7 @@ def normalise_whitespace(text):
 def normalise_text(text):
     """Normalise unicode and whitespace."""
     # Normalise unicode first to try and standardise whitespace characters as much as possible before normalising them
+    text = strip_control_characters(text)
     text = normalise_unicode(text)
     text = normalise_whitespace(text)
     return text
@@ -32,3 +33,17 @@ def simplify_html(text):
     text = normalise_text(text)
     text = text.replace(" <", "<").replace("> ", ">")
     return text
+
+
+def strip_control_characters(text):
+    """Strip out unicode control characters which might break the parsing."""
+    # Unicode control characters
+    #   [Cc]: Other, Control [includes new lines]
+    #   [Cf]: Other, Format
+    #   [Cn]: Other, Not Assigned
+    #   [Co]: Other, Private Use
+    #   [Cs]: Other, Surrogate
+    control_chars = set(['Cf','Cn','Co','Cs'])
+
+    # Remove non-printing control characters
+    return "".join(["" if unicodedata.category(char) in control_chars else char for char in text])


### PR DESCRIPTION
Closes #37 which was caused by BeautifulSoup escaping tags inside `<iframe>` tags. Solution is to blacklist `<iframe>` which touches on #31, but doesn't close it yet as the final decision may be different.

Added test cases for the above and also added escaping of control characters which was causing problems in the specific example from #37.