### PR TITLE
Trigger coveralls upload

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,5 @@ pyflakes
 pytest
 pytest-benchmark
 pytest-cov
+python-coveralls
 regex


### PR DESCRIPTION
This fixes the coveralls upload, by adding the missing dependency: `python-coveralls`. Closes #65.