### PR TITLE
Add support for isoformat dates with microseconds

### DIFF
--- a/readabilipy/extractors/extract_date.py
+++ b/readabilipy/extractors/extract_date.py
@@ -32,7 +32,8 @@ def ensure_iso_date_format(date_string, ignoretz=True):
         "%Y-%m-%dT%H:%M:%S",     # '2014-10-24T17:32:46'
         "%Y-%m-%dT%H:%M:%S%z",   # '2014-10-24T17:32:46+12:00'
         "%Y-%m-%dT%H:%M:%SZ",    # '2014-10-24T17:32:46Z'
-        "%Y-%m-%dT%H:%M:%S.%fZ"  # '2014-10-24T17:32:46.000Z'
+        "%Y-%m-%dT%H:%M:%S.%fZ",  # '2014-10-24T17:32:46.000Z'
+        "%Y-%m-%dT%H:%M:%S.%f"   # '2014-10-24T17:32:46.493'
     ]
 
     for date_format in supported_date_formats:
@@ -45,7 +46,7 @@ def ensure_iso_date_format(date_string, ignoretz=True):
             else:
                 isodate = datetime.strptime(date_string, date_format)
             if ignoretz:
-                isodate = isodate.replace(tzinfo=None)
+                isodate = isodate.replace(tzinfo=None, microsecond=0)
             return isodate.isoformat()
         except ValueError:
             pass

--- a/readabilipy/extractors/extract_date.py
+++ b/readabilipy/extractors/extract_date.py
@@ -29,11 +29,11 @@ def extract_date(html):
 def ensure_iso_date_format(date_string, ignoretz=True):
     """Check date_string is in one of our supported formats and return it"""
     supported_date_formats = [
-        "%Y-%m-%dT%H:%M:%S",     # '2014-10-24T17:32:46'
-        "%Y-%m-%dT%H:%M:%S%z",   # '2014-10-24T17:32:46+12:00'
-        "%Y-%m-%dT%H:%M:%SZ",    # '2014-10-24T17:32:46Z'
+        "%Y-%m-%dT%H:%M:%S",      # '2014-10-24T17:32:46'
+        "%Y-%m-%dT%H:%M:%S%z",    # '2014-10-24T17:32:46+12:00'
+        "%Y-%m-%dT%H:%M:%SZ",     # '2014-10-24T17:32:46Z'
         "%Y-%m-%dT%H:%M:%S.%fZ",  # '2014-10-24T17:32:46.000Z'
-        "%Y-%m-%dT%H:%M:%S.%f"   # '2014-10-24T17:32:46.493'
+        "%Y-%m-%dT%H:%M:%S.%f"    # '2014-10-24T17:32:46.493'
     ]
 
     for date_format in supported_date_formats:

--- a/tests/test_date_functions.py
+++ b/tests/test_date_functions.py
@@ -50,6 +50,12 @@ def test_ensure_iso_date_format_hh_colon_mmZ_format():
     assert ensure_iso_date_format(datetime_string) == expected_iso_string
 
 
+def test_ensure_iso_date_format_with_ms():
+    datetime_string = '2019-05-14T16:45:01.493'
+    expected_iso_string = '2019-05-14T16:45:01'
+    assert ensure_iso_date_format(datetime_string) == expected_iso_string
+
+
 htmls_with_expected = [
     ("""Hello world""", None),
     ("""10/10/2019""", None),


### PR DESCRIPTION
It's possible for the isodates found by the extract_date xpaths to be in this format e.g. '2014-10-24T17:32:46.493'

Update ReadabiliPy to support this 