### PR TITLE
Go for the next highest scoring date when the first is not isoformat

### DIFF
--- a/readabilipy/extractors/extract_date.py
+++ b/readabilipy/extractors/extract_date.py
@@ -23,9 +23,16 @@ def extract_date(html):
     extracted_dates = extract_element(html, xpaths)
     if not extracted_dates:
         return None
+
     # Set the date_string as that with the highest score assigned by extract_element
-    date_string = max(extracted_dates, key=lambda x: extracted_dates[x]["score"])
-    return ensure_iso_date_format(date_string)
+    # If this is not in isoformat, go with the higest scoring date_string that is
+    for _ in range(len(extracted_dates)):
+        date_string = max(extracted_dates, key=lambda x: extracted_dates[x]["score"])
+        iso_date = ensure_iso_date_format(date_string)
+        if iso_date:
+            return iso_date
+        extracted_dates.pop(date_string, None)  # Remove the higest scoring date from the dict
+    return None
 
 
 def ensure_iso_date_format(date_string, ignoretz=True):

--- a/readabilipy/extractors/extract_date.py
+++ b/readabilipy/extractors/extract_date.py
@@ -24,14 +24,11 @@ def extract_date(html):
     if not extracted_dates:
         return None
 
-    # Set the date_string as that with the highest score assigned by extract_element
-    # If this is not in isoformat, go with the higest scoring date_string that is
-    for _ in range(len(extracted_dates)):
-        date_string = max(extracted_dates, key=lambda x: extracted_dates[x]["score"])
+    # Search through the extracted date strings in order of score and take the first that is in isoformat
+    for date_string in sorted(extracted_dates, key=lambda ds: extracted_dates[ds]["score"], reverse=True):
         iso_date = ensure_iso_date_format(date_string)
         if iso_date:
             return iso_date
-        extracted_dates.pop(date_string, None)  # Remove the higest scoring date from the dict
     return None
 
 

--- a/tests/test_date_functions.py
+++ b/tests/test_date_functions.py
@@ -21,6 +21,12 @@ def test_extract_date(html, expected):
     assert extract_date(html) == expected
 
 
+def test_extract_date_finds_isoformat_from_lower_scoring_xpath_when_highest_scoring_not_isoformat():
+    html = """<meta property="article:published_time" content="2017-01-01" />
+                <meta property="article:modified_time" content="2019-01-01T00:00:00" />"""
+    expected = "2019-01-01T00:00:00"
+    assert extract_date(html) == expected
+
 def test_ensure_iso_date_format_timezone_keep():
     datetime_string = '2014-10-24T17:32:46+12:00'
     expected_iso_string = '2014-10-24T17:32:46+12:00'

--- a/tests/test_date_functions.py
+++ b/tests/test_date_functions.py
@@ -27,6 +27,7 @@ def test_extract_date_finds_isoformat_from_lower_scoring_xpath_when_highest_scor
     expected = "2019-01-01T00:00:00"
     assert extract_date(html) == expected
 
+
 def test_ensure_iso_date_format_timezone_keep():
     datetime_string = '2014-10-24T17:32:46+12:00'
     expected_iso_string = '2014-10-24T17:32:46+12:00'

--- a/tests/test_date_functions.py
+++ b/tests/test_date_functions.py
@@ -28,6 +28,13 @@ def test_extract_date_finds_isoformat_from_lower_scoring_xpath_when_highest_scor
     assert extract_date(html) == expected
 
 
+def test_extract_date_all_dates_not_isoformat():
+    html = """<meta property="article:published_time" content="2017-01-01" />
+                <meta property="article:modified_time" content="2019-01-01" />"""
+    expected = None
+    assert extract_date(html) == expected
+
+
 def test_ensure_iso_date_format_timezone_keep():
     datetime_string = '2014-10-24T17:32:46+12:00'
     expected_iso_string = '2014-10-24T17:32:46+12:00'


### PR DESCRIPTION
Go for the next highest scroring date when the first is not isoformat

This will fix an issue in misinformation-crawler: https://github.com/alan-turing-institute/misinformation-crawler/issues/295