### PR TITLE
fix issue-109 (use unique temp files for input/output of ExtractArticle.js)

### DIFF
--- a/readabilipy/simple_json.py
+++ b/readabilipy/simple_json.py
@@ -50,15 +50,14 @@ def simple_json_from_html_string(html, content_digests=False, node_indexes=False
             f_html.close()
         html_path = f_html.name
 
-        # Derive some output name
-        # (making the assumption this will be unique too)
+        # We assume appending ".json" to the html name will also be a unique filename
         json_path = html_path + ".json"
 
         # Call Mozilla's Readability.js Readability.parse() function via node, writing output to a temporary file
         jsdir = os.path.join(os.path.dirname(__file__), 'javascript')
         try:
             subprocess.run(
-                ["node", "ExtractArticle.js", "-i", html_path, "-o", article_json_path],
+                ["node", "ExtractArticle.js", "-i", html_path, "-o", json_path],
                 cwd=jsdir,
                 check=True,
                 stdout=subprocess.PIPE,

--- a/readabilipy/simple_json.py
+++ b/readabilipy/simple_json.py
@@ -48,16 +48,16 @@ def simple_json_from_html_string(html, content_digests=False, node_indexes=False
         with tempfile.NamedTemporaryFile(delete=False, mode="w+", encoding="utf-8", prefix="readabilipy") as f_html:
             f_html.write(html)
             f_html.close()
-        html_path = f_html.name
+        tmp_html_path = f_html.name
 
         # We assume appending ".json" to the html name will also be a unique filename
-        json_path = html_path + ".json"
+        tmp_json_path = tmp_html_path + ".json"
 
         # Call Mozilla's Readability.js Readability.parse() function via node, writing output to a temporary file
         jsdir = os.path.join(os.path.dirname(__file__), 'javascript')
         try:
             subprocess.run(
-                ["node", "ExtractArticle.js", "-i", html_path, "-o", json_path],
+                ["node", "ExtractArticle.js", "-i", tmp_html_path, "-o", tmp_json_path],
                 cwd=jsdir,
                 check=True,
                 stdout=subprocess.PIPE,
@@ -68,12 +68,12 @@ def simple_json_from_html_string(html, content_digests=False, node_indexes=False
             raise
 
         # Read output of call to Readability.parse() from JSON file as Python dictionary
-        with open(json_path, "r", encoding="utf-8") as json_file:
+        with open(tmp_json_path, "r", encoding="utf-8") as json_file:
             input_json = json.load(json_file)
 
         # Delete temporary input and output files after processing
-        os.unlink(json_path)
-        os.unlink(f_html.name)
+        os.unlink(tmp_json_path)
+        os.unlink(tmp_html_path)
     else:
         input_json = {
             "title": extract_title(html),

--- a/tests/checks.py
+++ b/tests/checks.py
@@ -51,7 +51,7 @@ def check_extract_article(test_filename, expected_filename, content_digests=Fals
         expected_article_json = json.loads(h.read())
 
     # Test full JSON matches (checks for unexpected fields in either actual or expected JSON)
-    assert article_json == expected_article_json
+    assert article_json == expected_article_json, f"{article_json=} != {expected_article_json=}"
 
 
 def check_extract_paragraphs_as_plain_text(test_filename, expected_filename):

--- a/tests/checks.py
+++ b/tests/checks.py
@@ -51,7 +51,7 @@ def check_extract_article(test_filename, expected_filename, content_digests=Fals
         expected_article_json = json.loads(h.read())
 
     # Test full JSON matches (checks for unexpected fields in either actual or expected JSON)
-    assert article_json == expected_article_json, f"{article_json=} != {expected_article_json=}"
+    assert article_json == expected_article_json
 
 
 def check_extract_paragraphs_as_plain_text(test_filename, expected_filename):


### PR DESCRIPTION
It appears that something had previously been started to address this issue but was left as is with some 'json_path' undefined.

previously:
```
make test

FAILED test_javascript.py::test_extract_simple_article_with_readability_js - NameError: name 'json_path' is not defined
FAILED test_javascript.py::test_extract_article_from_page_with_readability_js - NameError: name 'json_path' is not defined
FAILED test_simple_json.py::test_plain_element_with_comments - AssertionError: assert ['<div></div>'] == ['<div><p>Tex...!----></div>']
FAILED test_simple_json.py::test_content_digest_on_filled_and_empty_elements - assert ['<div></div>'] == ['<div><p dat..."></p></div>']
```

unfortunately tests still don't pass with proposed changes:
```
FAILED test_javascript.py::test_extract_simple_article_with_readability_js - AssertionError: article_json={'title': None, 'byline': None, 'date': None, 'content': '<div id="readability-page-1" class="page"><div class="page">\n                <article>\n                    <h2> Article title </h2>\n                    <p>\n                        Proin vulputate viverra dapibus...
FAILED test_javascript.py::test_extract_article_from_page_with_readability_js - AssertionError: article_json={'title': 'Trump Denies Charitable Donation He Promised If Elizabeth Warren Releases DNA Results And It’s On Video', 'byline': 'Conover Kennard', 'date': None, 'content': '<div id="readability-page-1" class="page"><div id="post-342398">\n\n\n\n<div>\n<p>Donald Trump has re...
FAILED test_simple_json.py::test_plain_element_with_comments - AssertionError: assert ['<div></div>'] == ['<div><p>Tex...!----></div>']
FAILED test_simple_json.py::test_content_digest_on_filled_and_empty_elements - assert ['<div></div>'] == ['<div><p dat..."></p></div>']
=
```

but this appears to be due only to extra \n in the 'content' field and the other fields are correct.

<img width="1635" alt="diff_meta_fields_correct" src="https://github.com/user-attachments/assets/a83a72c0-0d0b-47d7-94c1-e3586dd9dc73">
<img width="1635" alt="diff_extra_linebreaks_present" src="https://github.com/user-attachments/assets/6d56fa68-f506-4cf9-a873-02db14ac6b58">


