### PR TITLE
Fix for UnicodeDecodeError: 'utf-8' codec can't decode bytes

### DIFF
--- a/readabilipy/__main__.py
+++ b/readabilipy/__main__.py
@@ -55,7 +55,7 @@ def main():
 
     args = parser.parse_args()
 
-    with open(args.input_file, encoding="utf-8") as h:
+    with open(args.input_file, encoding="utf-8", errors="replace") as h:
         html = h.read()
 
     article = simple_json_from_html_string(


### PR DESCRIPTION
Readabilipy fails with a following error when invalid UTF-8 data is being read. Way to reproduce it (on Mac/Linux with `uv` installed):

```~> command uvx -qn readabilipy@0.2.0 -p -o /dev/stdout -i <(curl -L https://bicycledutch.wordpress.com/2018/02/20/a-common-urban-intersection-in-the-netherlands/)
Traceback (most recent call last):
  File "/private/var/folders/6s/zmqh70095p121_q_442tjp5w0000gp/T/.tmpGYSFa2/archive-v0/kd2BMkWGwPKa67VK9GnJ0/bin/readabilipy", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/private/var/folders/6s/zmqh70095p121_q_442tjp5w0000gp/T/.tmpGYSFa2/archive-v0/kd2BMkWGwPKa67VK9GnJ0/lib/python3.12/site-packages/readabilipy/__main__.py", line 59, in main
    html = h.read()
           ^^^^^^^^
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 108264-108265: invalid continuation byte```

The change I propose fixes the issue replacing invalid symbols with `?` instead of throwing an exception.