### PR TITLE
Use stdin as input and stdout as output files

### DIFF
--- a/readabilipy/__main__.py
+++ b/readabilipy/__main__.py
@@ -59,7 +59,8 @@ def main():
 
     # Open input file or stream
     if args.input_file == "-":
-        sys.stdin.reconfigure(encoding="utf-8", errors="replace")
+        if hasattr(sys.stdin, "reconfigure"):
+            sys.stdin.reconfigure(encoding="utf-8", errors="replace")
         input_file = sys.stdin
     else:
         input_file = open(args.input_file, encoding="utf-8", errors="replace")  # pylint: disable=consider-using-with

--- a/readabilipy/__main__.py
+++ b/readabilipy/__main__.py
@@ -56,15 +56,18 @@ def main():
     )
 
     args = parser.parse_args()
-    sys.stdin.reconfigure(encoding="utf-8", errors="replace")
-    input_file = sys.stdin
-    output_file = sys.stdout
-    if args.input_file != "-":
-        input_file = open(args.input_file, encoding="utf-8", errors="replace")
-    if args.output_file != "-":
-        output_file = open(args.output_file, "w", encoding="utf-8")
 
+    # Open input file or stream
+    if args.input_file == "-":
+        sys.stdin.reconfigure(encoding="utf-8", errors="replace")
+        input_file = sys.stdin
+    else:
+        input_file = open(args.input_file, encoding="utf-8", errors="replace")
+
+    # Read from input then close if appropriate
     html = input_file.read()
+    if not input_file.isatty():
+        input_file.close()
 
     article = simple_json_from_html_string(
         html,
@@ -73,10 +76,14 @@ def main():
         use_readability=(not args.use_python_parser),
     )
 
-    json.dump(article, output_file, ensure_ascii=False)
+    # Open output file or stream
+    if args.output_file == "-":
+        output_file = sys.stdout
+    else:
+        output_file = open(args.output_file, "w", encoding="utf-8")
 
-    if not input_file.isatty():
-        input_file.close()
+    # Write to output then close if appropriate
+    json.dump(article, output_file, ensure_ascii=False)
     if not output_file.isatty():
         output_file.close()
 

--- a/readabilipy/__main__.py
+++ b/readabilipy/__main__.py
@@ -62,7 +62,7 @@ def main():
         sys.stdin.reconfigure(encoding="utf-8", errors="replace")
         input_file = sys.stdin
     else:
-        input_file = open(args.input_file, encoding="utf-8", errors="replace")
+        input_file = open(args.input_file, encoding="utf-8", errors="replace")  # pylint: disable=consider-using-with
 
     # Read from input then close if appropriate
     html = input_file.read()
@@ -80,7 +80,7 @@ def main():
     if args.output_file == "-":
         output_file = sys.stdout
     else:
-        output_file = open(args.output_file, "w", encoding="utf-8")
+        output_file = open(args.output_file, "w", encoding="utf-8")  # pylint: disable=consider-using-with
 
     # Write to output then close if appropriate
     json.dump(article, output_file, ensure_ascii=False)


### PR DESCRIPTION
This PR adds the ability to read from standard input and to write to standard output. Example:

    > curl -L https://bicycledutch.wordpress.com/2018/02/20/a-common-urban-intersection-in-the-netherlands/ \
    | python -m readabilipy -p \
    | jq '.title'
    "A common urban intersection in the Netherlands"
